### PR TITLE
fix: docs readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Easy-to-use memory for agents, document search, knowledge graphing and more.
 [![Lint and Test](https://github.com/AutonomousResearchGroup/agentmemory/actions/workflows/test.yml/badge.svg)](https://github.com/AutonomousResearchGroup/agentmemory/actions/workflows/test.yml)
 [![PyPI version](https://badge.fury.io/py/agentmemory.svg)](https://badge.fury.io/py/agentmemory)
 [![License](https://img.shields.io/badge/License-MIT-blue)](https://github.com/AutonomousResearchGroup/easycompletion/blob/main/LICENSE)
-[![forks - easycompletion](https://img.shields.io/github/forks/AutonomousResearchGroup/easycompletion?style=social)](https://github.com/AutonomousResearchGroup/easycompletion)
+[![forks - easycompletion](https://img.shields.io/github/forks/AutonomousResearchGroup/easycompletion?style=social)](https://github.com/elizaOS/easycompletion/forks)
 
 # Installation
 


### PR DESCRIPTION
changed the link in the documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated GitHub forks badge URL to point to the new repository location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->